### PR TITLE
Function get_cpu_percent_linux gives ValueError when running for all CPU processes

### DIFF
--- a/eco2ai/tools/tools_cpu.py
+++ b/eco2ai/tools/tools_cpu.py
@@ -529,14 +529,14 @@ def get_cpu_percent_linux(cpu_processes="current"):
     elif cpu_processes == "all":
         strings = os.popen('top -i -b -n 1').read()
         strings = strings.split('\n')
-        strings.pop()
-        flag_string = '  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND'
-        index_cpu = strings.index(flag_string)
+        index_cpu = [i for i, elem in enumerate(strings) if 'PID USER' in elem]
+        index_cpu = index_cpu[-1]
         strings = strings[index_cpu+1:]
         try:
-            index_cpu = strings[0].split().index('R') + 1
             for string in strings:
-                cpu_sum += float(string.split()[index_cpu])
+                string_list = string.split()
+                if string_list[7] == "R":
+                    cpu_sum += float(string.split()[8])
         except IndexError: 
             pass
         cpu_percent = cpu_sum / cpu_num / 100


### PR DESCRIPTION
Hello,

When creating a CPU-based tracker on a Linux machine and trying to measure the power consumption for all CPU processed combined (cpu_processes="all"), I get the following ValueError:

```
Traceback (most recent call last):
  File "/home/synergia/.cache/pypoetry/virtualenvs/sustainable-ai-b93ea8Cf-py3.9/lib/python3.9/site-packages/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
  File "/home/synergia/.cache/pypoetry/virtualenvs/sustainable-ai-b93ea8Cf-py3.9/lib/python3.9/site-packages/eco2ai/emission_track.py", line 532, in _func_for_sched
    cpu_consumption = self._cpu.calculate_consumption()
  File "/home/synergia/.cache/pypoetry/virtualenvs/sustainable-ai-b93ea8Cf-py3.9/lib/python3.9/site-packages/eco2ai/tools/tools_cpu.py", line 151, in calculate_consumption
    consumption = self._tdp * self.get_cpu_percent() * self._cpu_num * time_period / FROM_WATTs_TO_kWATTh
  File "/home/synergia/.cache/pypoetry/virtualenvs/sustainable-ai-b93ea8Cf-py3.9/lib/python3.9/site-packages/eco2ai/tools/tools_cpu.py", line 132, in get_cpu_percent
    cpu_percent = os_dict[self._operating_system](self._cpu_processes)
  File "/home/synergia/.cache/pypoetry/virtualenvs/sustainable-ai-b93ea8Cf-py3.9/lib/python3.9/site-packages/eco2ai/tools/tools_cpu.py", line 534, in get_cpu_percent_linux
    index_cpu = strings.index(flag_string)
ValueError: '  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND' is not in list
```

This is due to how _top_ prints on different terminals and terminal widths. In my setup _top_ was printing one more empty space before PID. 

I introduced a more generalised way of getting the results that matches _top_ output using a substring instead of the entire line.

Try-except was also modified as _top_ may produce results with processes marked as _sleeping_ ('S' state). These processes don't consume CPU resources and, therefore, don't contribute to the overall power consumption. 
