### PR TITLE
Feature for sending consumption data via webhook

### DIFF
--- a/eco2ai/emission_track.py
+++ b/eco2ai/emission_track.py
@@ -397,6 +397,14 @@ You can find the ISO-Alpha-2 code of your country here: https://www.iban.com/cou
         return attributes_dict
 
     def send_json(self, data):
+        """
+            This class method send data to webhook.
+
+            Parameters
+            ----------
+            data: dict
+                Dictionary with all the attributes that should be sended.
+        """
         try:
             response = requests.post(self.webhook_url, json=data,
                                      timeout=self._measure_period/2)


### PR DESCRIPTION
To use, you need to pass a parameter with a string to the url. For Example:
```python
import time

from eco2ai import Tracker

tracker = Tracker(
    alpha_2_code="RU",
    region="Primorskiy Kray",
    cpu_processes="all",
    webhook_url="http://localhost:8000/webhook", # <--
    measure_period=1,
)

tracker.start()

for i in range(10):
    time.sleep(1)

tracker.stop()
```

I wrote a test server to test. To run it, you need to write the command ``docker run -p 8000:8000 -t ada0l/ada0l-eco2ai-playground``