### PR TITLE
webhook timeout

### DIFF
--- a/eco2ai/emission_track.py
+++ b/eco2ai/emission_track.py
@@ -58,6 +58,7 @@ class Tracker:
         project_name=None,
         experiment_description=None,
         webhook_url=None,
+        webhook_timeout=2,
         file_name=None,
         measure_period=10,
         emission_level=None,
@@ -158,6 +159,7 @@ You can find the ISO-Alpha-2 code of your country here: https://www.iban.com/cou
         self.project_name = project_name if project_name is not None else self._params_dict["project_name"]
         self.experiment_description = experiment_description if experiment_description is not None else self._params_dict["experiment_description"]
         self.webhook_url = webhook_url
+        self.webhook_timeout = webhook_timeout
         self.file_name = file_name if file_name is not None else self._params_dict["file_name"]
         self._measure_period = measure_period if measure_period is not None else self._params_dict["measure_period"]
         self._pue = pue if pue is not None else self._params_dict["pue"]
@@ -406,8 +408,11 @@ You can find the ISO-Alpha-2 code of your country here: https://www.iban.com/cou
                 Dictionary with all the attributes that should be sended.
         """
         try:
-            response = requests.post(self.webhook_url, json=data,
-                                     timeout=self._measure_period/2)
+            response = requests.post(
+                self.webhook_url,
+                json=data,
+                timeout=self.webhook_timeout,
+            )
             if response.status_code != 200:
                 warnings.warn("Unexpected status code from host")
         except Exception as ex:

--- a/eco2ai/emission_track.py
+++ b/eco2ai/emission_track.py
@@ -81,6 +81,12 @@ class Tracker:
             experiment_description: str 
                 Specified by user experiment description.
                 The default is None
+            webhook_url: str
+                Endpoint for sending consumption data.
+                The default is None
+            webhook_timeout: float
+                The timeout period for the webhook in seconds.
+                The default is 2
             file_name: str
                 Name of file to save the the results of calculations.
                 The default is None

--- a/eco2ai/emission_track.py
+++ b/eco2ai/emission_track.py
@@ -397,6 +397,14 @@ You can find the ISO-Alpha-2 code of your country here: https://www.iban.com/cou
         return attributes_dict
 
     def send_json(self, data):
+        """
+            This class method send data to webhook.
+
+            Parameters
+            ----------
+            data: dict
+                Dictionary with all the attributes that should be sended.
+        """
         try:
             response = requests.post(self.webhook_url, json=data,
                                      timeout=self._measure_period/2)


### PR DESCRIPTION
Allows you to manually set a timeout. The idea of setting the timeout to half of the measurement period was bad, as it is wrong to keep the connection, for example, 30 seconds. Typically web servers should respond within 0.1 to 0.3 seconds.

I also added ``webhook_url`` and ``webhook_timeout`` to the docstring in ``Tracker.__init__``.