### PR TITLE
docstring typo fix

### DIFF
--- a/eco2ai/tools/tools_gpu.py
+++ b/eco2ai/tools/tools_gpu.py
@@ -57,7 +57,7 @@ class GPU:
         Returns
         -------
         consumption: float
-            CPU power consumption
+            GPU power consumption
         """
         if not self.is_gpu_available:
             return 0
@@ -82,7 +82,7 @@ class GPU:
         Returns
         -------
         self._consumption: float
-            CPU power consumption
+            GPU power consumption
 
         """
         if not self.is_gpu_available:


### PR DESCRIPTION
Typos were found in the documentation for the tools_gpu.py file regarding the device name:
```python
    def get_consumption(self):
        """
        This class method returns GPU power consupmtion amount.

        Parameters
        ----------
        No parameters

        Returns
        -------
        self._consumption: float
            CPU power consumption

        """
        if not self.is_gpu_available:
            return 0
        return self._consumption
```
for example in this case CPU should be replaced with GPU.
